### PR TITLE
Keep transparency of avatar

### DIFF
--- a/feditree.py
+++ b/feditree.py
@@ -83,7 +83,7 @@ def create_image(accounts):
             handler.write(avatar_data)
         with Image.open('feditree/avatar.png') as avatar:
             avatar.load()
-        avatar = avatar.resize((100,100)).convert("RGB")
+        avatar = avatar.resize((100,100)).convert("RGBA")
         avatar.paste(bola_radio, (0,0), bola_radio)
         feditree.paste(avatar, coordinates[i], bola_mask)
     feditree.save("feditree/feditree.png")


### PR DESCRIPTION
If the avatar had a transparent background, keep the information

Fixes #7

Before :
<img width="800" height="844" alt="7e17cdbb766c43b7" src="https://github.com/user-attachments/assets/63019644-2159-415f-b625-8031badb2445" />

After:
<img width="800" height="844" alt="feditree" src="https://github.com/user-attachments/assets/f62e9d35-5c96-479e-b851-6f088b3ce878" />
